### PR TITLE
Migrate redis flush to "new" del-function too

### DIFF
--- a/src/Backend/PHPRedis.php
+++ b/src/Backend/PHPRedis.php
@@ -109,7 +109,7 @@ class PHPRedis implements Backend, Iterator
         $keys = $redis->keys("$prefix*");
         $query = $redis->multi(\Redis::PIPELINE);
         foreach ($keys as $key) {
-            $query->delete($key);
+            $query->del($key);
         }
         $query->exec();
     }


### PR DESCRIPTION
Found another occurance of the old delete method which is "soft deprecated" since version 5.0.0 of php-redis.